### PR TITLE
fix: Prune tags before release

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -33,6 +33,9 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
+
+      - name: Prune tags
+        run: git fetch --prune --tags
 
       - name: Semantic Release
         id: semantic


### PR DESCRIPTION
## 1. Description
Pruning git tags solves some issues that prevent `semantic-release` from publishing a new version.