### PR TITLE
feat(admin): Create property inline for host when scheduling

### DIFF
--- a/src/features/cleanings/components/CleaningForm.tsx
+++ b/src/features/cleanings/components/CleaningForm.tsx
@@ -25,6 +25,7 @@ import type { CleaningRequest } from '@/features/cleanings/types';
 import { STATUS_GROUPS } from '@/features/cleanings/types';
 import { PropertyForm } from '@/features/properties/components/PropertyForm';
 import { useProperties } from '@/features/properties/PropertyContext';
+import { propertyService } from '@/features/properties/propertyService';
 import type { Property, PropertyInsert } from '@/features/properties/types';
 
 const cleaningFormSchema = z.object({
@@ -54,6 +55,8 @@ interface CleaningFormProps {
 	onSubmit: (values: CleaningFormValues) => Promise<void>;
 	onCancel?: () => void;
 	disableCreateProperty?: boolean;
+	hostId?: string;
+	onPropertyCreated?: (property: Property) => void;
 	availableProperties?: {
 		id: string;
 		address_line_1: string;
@@ -69,6 +72,8 @@ export function CleaningForm({
 	onSubmit,
 	disableCreateProperty = false,
 	availableProperties,
+	hostId,
+	onPropertyCreated,
 }: CleaningFormProps) {
 	const isRestricted = initialData
 		? STATUS_GROUPS.CAN_EDIT_RESTRICTED.includes(initialData.status)
@@ -80,9 +85,10 @@ export function CleaningForm({
 	const [standardTasks, setStandardTasks] = useState<{ id: string; description: string }[]>([]);
 	const [standardTasksLoading, setStandardTasksLoading] = useState(false);
 	const [standardTasksError, setStandardTasksError] = useState<string | null>(null);
+	const [adminProperties, setAdminProperties] = useState<Property[]>([]);
 	const { properties: contextProperties, upsertProperty } = useProperties();
 
-	const displayedProperties = availableProperties || contextProperties;
+	const displayedProperties = availableProperties || [...adminProperties, ...contextProperties];
 
 	const dict = DICT.CLEANINGS.FORM;
 
@@ -175,15 +181,34 @@ export function CleaningForm({
 	}, [selectedProperty]);
 
 	const handlePropertySubmit = async (propertyData: PropertyInsert): Promise<void> => {
-		const result = await upsertProperty(propertyData);
-		if (result.data) {
-			const property = result.data as Property;
-			setValue('property_id', property.id, {
-				shouldValidate: true,
-				shouldDirty: true,
-				shouldTouch: true,
-			});
-			setStep(2);
+		if (hostId) {
+			const { data, error } = await propertyService.upsertProperty(propertyData);
+			if (error) {
+				toast.error(error);
+				return;
+			}
+			if (data) {
+				const property = data as Property;
+				setAdminProperties((prev) => [property, ...prev]);
+				onPropertyCreated?.(property);
+				setValue('property_id', property.id, {
+					shouldValidate: true,
+					shouldDirty: true,
+					shouldTouch: true,
+				});
+				setStep(2);
+			}
+		} else {
+			const result = await upsertProperty(propertyData);
+			if (result.data) {
+				const property = result.data as Property;
+				setValue('property_id', property.id, {
+					shouldValidate: true,
+					shouldDirty: true,
+					shouldTouch: true,
+				});
+				setStep(2);
+			}
 		}
 	};
 
@@ -207,6 +232,7 @@ export function CleaningForm({
 					onSubmit={handlePropertySubmit}
 					onCancel={handlePropertyFormCancel}
 					cancelLabel={DICT.COMMON.ACTIONS.BACK}
+					hostId={hostId}
 				/>
 			) : (
 				<form onSubmit={handleSubmit(handleFinalSubmit)} className="space-y-6">
@@ -224,7 +250,9 @@ export function CleaningForm({
 											onClick={() => setEntryMode('create')}>
 											{dict.LABELS.NEW_PROPERTY}
 										</Button>
-										<p className="text-center font-medium">OR</p>
+										{displayedProperties.length > 0 && (
+											<p className="text-center font-medium">OR</p>
+										)}
 									</>
 								)}
 								{displayedProperties.length > 0 && (

--- a/src/features/properties/components/PropertyForm.tsx
+++ b/src/features/properties/components/PropertyForm.tsx
@@ -66,9 +66,16 @@ interface PropertyFormProps {
 	onSubmit: (data: PropertyInsert) => Promise<void>;
 	onCancel: () => void;
 	cancelLabel?: string;
+	hostId?: string;
 }
 
-export function PropertyForm({ initialData, onSubmit, onCancel, cancelLabel }: PropertyFormProps) {
+export function PropertyForm({
+	initialData,
+	onSubmit,
+	onCancel,
+	cancelLabel,
+	hostId,
+}: PropertyFormProps) {
 	const { user } = useAuth();
 
 	const {
@@ -120,7 +127,7 @@ export function PropertyForm({ initialData, onSubmit, onCancel, cancelLabel }: P
 
 		const payload: PropertyInsert = {
 			...databaseValues,
-			host_id: user.id,
+			host_id: hostId ?? user.id,
 			main_image_url: mainImagePath,
 			extra_images_urls: finalExtraImagesPaths,
 		};

--- a/src/pages/admin/HostDetail.tsx
+++ b/src/pages/admin/HostDetail.tsx
@@ -305,7 +305,8 @@ export function AdminHostDetailPage() {
 							<CleaningForm
 								onSubmit={handleCreateCleaning}
 								onCancel={() => setIsCreateModalOpen(false)}
-								disableCreateProperty={true}
+								hostId={host?.id}
+								onPropertyCreated={refresh}
 								availableProperties={properties}
 							/>
 						</FormContainer>


### PR DESCRIPTION
When an admin schedules a cleaning for a host with no properties, step 1 of the CleaningForm rendered empty because disableCreateProperty was hardcoded to true.

- Add hostId prop to PropertyForm to set host_id on the target host instead of the admin
- Add hostId and onPropertyCreated props to CleaningForm for admin property creation
- Use propertyService directly when hostId is provided